### PR TITLE
chore(deps): update astro to version 5

### DIFF
--- a/.changeset/heavy-donkeys-boil.md
+++ b/.changeset/heavy-donkeys-boil.md
@@ -1,0 +1,5 @@
+---
+"astro-loading-indicator": minor
+---
+
+Adds support for Astro 5.0

--- a/package/package.json
+++ b/package/package.json
@@ -25,6 +25,6 @@
 	"scripts": {},
 	"type": "module",
 	"peerDependencies": {
-		"astro": "^5.0.0"
+		"astro": "^4.0.0 || ^5.0.0"
 	}
 }

--- a/package/package.json
+++ b/package/package.json
@@ -25,6 +25,6 @@
 	"scripts": {},
 	"type": "module",
 	"peerDependencies": {
-		"astro": "^4.0.0"
+		"astro": "^5.0.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
   package:
     dependencies:
       astro:
-        specifier: ^4.0.0
+        specifier: ^4.0.0 || ^5.0.0
         version: 4.6.3(@types/node@20.12.7)(typescript@5.4.5)
 
   playground:


### PR DESCRIPTION
# Updated Astro v4 to v5

## Description
Updated the `astro` dependency from version `v4` to `v5` in the `package.json` of the main package.

## Changes
- Updated `astro` version in `package/package.json`:  

  ```json
  "astro": "^5.0.0"
