### PR TITLE
Replace `ViewTransitions` with `ClientRouter`

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -30,14 +30,14 @@ yarn add astro-loading-indicator
 
 ```diff
 ---
-import { ViewTransitions } from "astro:transitions";
+import { ClientRouter } from "astro:transitions";
 +import LoadingIndicator from "astro-loading-indicator/component"
 
 ---
 <!doctype html>
 <html>
   <head>
-  	<ViewTransitions />
+  	<ClientRouter />
 +		<LoadingIndicator />
   </head>
 </html>

--- a/playground/src/layouts/Layout.astro
+++ b/playground/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-import { ViewTransitions } from "astro:transitions";
+import { ClientRouter } from "astro:transitions";
 import LoadingIndicator from "astro-loading-indicator/component";
 
 interface Props {
@@ -18,7 +18,7 @@ const { title } = Astro.props;
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
 		<title>{title}</title>
-		<ViewTransitions />
+		<ClientRouter />
 		<LoadingIndicator color="green" height="6px" class="custom-loading-class" />
 	</head>
 	<body>


### PR DESCRIPTION
### Outline

As per the [Astro docs](https://docs.astro.build/en/guides/view-transitions/), the transitions have been updated to use `ClientRouter` rather than `ViewTransitions`.

This PR updates the mentions to reflect this.